### PR TITLE
buffer length fixed

### DIFF
--- a/natsclient.h
+++ b/natsclient.h
@@ -496,7 +496,7 @@ namespace Nats
         // track movement inside buffer for parsing
         int last_pos = 0, current_pos = 0;
 
-        while(last_pos != buffer.length())
+        while(last_pos != buffer.toUtf8.length())
         {
 
             // we always get delimited message


### PR DESCRIPTION
utf8 length might be longer than buffer.length().