### PR TITLE
Update natsclient.h: change type of error_message variable.

### DIFF
--- a/natsclient.h
+++ b/natsclient.h
@@ -525,7 +525,7 @@ namespace Nats
             // if -ERR, close client connection | -ERR <error message>
             else if(operation.indexOf("-ERR", 0, Qt::CaseInsensitive) != -1)
             {
-                QStringRef error_message = &(operation.mid(4));
+                QString error_message = operation.mid(4);
                 qCritical() << "error" << error_message;
 
                 if(error_message.compare(QStringLiteral("Invalid Subject")) != 0)


### PR DESCRIPTION
I changed line 528 because in it't original form it caused compilation error:  ...NATS_CLIENT\natsclient.h:528: error: taking address of temporary [-fpermissive]
                 QStringRef error_message = &(operation.mid(4));
                                                              ^